### PR TITLE
Fix #1: Find, parse, and update the .NET bundle manifest

### DIFF
--- a/Topten.nvpatch/BundleHelper.cs
+++ b/Topten.nvpatch/BundleHelper.cs
@@ -1,0 +1,92 @@
+﻿// Portions of the below code are taken from the .NET runtime's source code.
+// Please see: https://github.com/dotnet/runtime/tree/main/src/installer/managed/Microsoft.NET.HostModel/
+
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+
+using System;
+using System.IO;
+
+namespace nvpatch
+{
+    static class BundleHelper
+    {
+        const int ManifestAddressLength = sizeof(long);
+        // The preceding 8 bytes to this signature contain the address of the
+        // bundle manifest.
+        static readonly byte[] BundleHeaderSignature = {
+            // 32 bytes represent the bundle signature: SHA-256 for ".net core bundle"
+            0x8b, 0x12, 0x02, 0xb9, 0x6a, 0x61, 0x20, 0x38,
+            0x72, 0x7b, 0x93, 0x02, 0x14, 0xd7, 0xa0, 0x32,
+            0x13, 0xf5, 0xb9, 0xe6, 0xef, 0xae, 0x33, 0x18,
+            0xee, 0x3b, 0x2d, 0xce, 0x24, 0xb3, 0x6a, 0xae
+        };
+
+        public static void CheckForAndUpdateManifest(byte[] inputBytes, FileStream outputStream, long offset)
+        {
+            var signaturePosition = Utils.KMPSearch(BundleHeaderSignature, inputBytes);
+            if (signaturePosition < 0)
+                return; // Nothing to do, no bundle marker found.
+
+            var manifestPointerPosition = signaturePosition - ManifestAddressLength;
+
+            var manifestPosition = BitConverter.ToInt64(inputBytes[manifestPointerPosition..]);
+            if (manifestPosition == 0)
+                return; // Nothing to do, this .NET executable has no bundle.
+
+            // Update the position of the manifest in the output.
+            outputStream.Position = manifestPointerPosition;
+            outputStream.Write(BitConverter.GetBytes(manifestPosition + offset));
+
+            /* The below code is a rough implementation of the
+             * .NET Bundle Manifest format, which contains offsets
+             * to files stored after the "AppHost" PE file. Because
+             * we've just added more content to the PE file, we need
+             * to update the bundle manifest to reflect the new locations
+             * of these files, otherwise the AppHost will fail
+             * to run the .NET application correctly.
+             */
+
+            using var inputStream = new MemoryStream(inputBytes);
+            using var reader = new BinaryReader(inputStream);
+            inputStream.Position = manifestPosition;
+
+            void ReadInt64OffsetAndUpdate()
+            {
+                outputStream.Position = inputStream.Position + offset;
+                var readValue = reader.ReadInt64();
+                if (readValue > 0)
+                    outputStream.Write(BitConverter.GetBytes(readValue + offset));
+            }
+
+            var majorVersion = reader.ReadUInt32();
+            _ = reader.ReadUInt32(); // Minor version.
+            var fileCount = reader.ReadInt32();
+            _ = reader.ReadString(); // Bundle ID
+
+            if (majorVersion >= 2)
+            {
+                ReadInt64OffsetAndUpdate(); // depsJsonOffset
+                _ = reader.ReadInt64(); // depsJsonSize
+
+                ReadInt64OffsetAndUpdate(); // runtimeConfigJsonOffset
+                _ = reader.ReadInt64(); // runtimeConfigJsonSize
+
+                _ = reader.ReadUInt64(); // flags
+            }
+
+            for (var i = 0; i < fileCount; i++)
+            {
+                ReadInt64OffsetAndUpdate(); // fileOffset
+                _ = reader.ReadInt64(); // fileSize
+
+                if (majorVersion >= 6)
+                    _ = reader.ReadInt64(); // compressedSize
+
+                _ = reader.ReadByte(); // type
+                _ = reader.ReadString(); // path
+            }
+        }
+    }
+}

--- a/Topten.nvpatch/Utils.cs
+++ b/Topten.nvpatch/Utils.cs
@@ -63,5 +63,87 @@ namespace nvpatch
                 return false;
             }
         }
+
+
+        #region Code from .NET Runtime Source
+
+        // Portions of the below code are taken from the .NET runtime's source code.
+        // Please see: https://github.com/dotnet/runtime/tree/main/src/installer/managed/Microsoft.NET.HostModel/
+
+        // Licensed to the .NET Foundation under one or more agreements.
+        // The .NET Foundation licenses this file to you under the MIT license.
+
+        // See: https://en.wikipedia.org/wiki/Knuth%E2%80%93Morris%E2%80%93Pratt_algorithm
+        public static int[] ComputeKMPFailureFunction(byte[] pattern)
+        {
+            int[] table = new int[pattern.Length];
+            if (pattern.Length >= 1)
+            {
+                table[0] = -1;
+            }
+            if (pattern.Length >= 2)
+            {
+                table[1] = 0;
+            }
+
+            int pos = 2;
+            int cnd = 0;
+            while (pos < pattern.Length)
+            {
+                if (pattern[pos - 1] == pattern[cnd])
+                {
+                    table[pos] = cnd + 1;
+                    cnd++;
+                    pos++;
+                }
+                else if (cnd > 0)
+                {
+                    cnd = table[cnd];
+                }
+                else
+                {
+                    table[pos] = 0;
+                    pos++;
+                }
+            }
+            return table;
+        }
+
+        // See: https://en.wikipedia.org/wiki/Knuth%E2%80%93Morris%E2%80%93Pratt_algorithm
+        public static int KMPSearch(byte[] pattern, ReadOnlySpan<byte> bytes)
+        {
+            int m = 0;
+            int i = 0;
+            int[] table = ComputeKMPFailureFunction(pattern);
+
+            while (m + i < bytes.Length)
+            {
+                if (pattern[i] == bytes[m + i])
+                {
+                    if (i == pattern.Length - 1)
+                    {
+                        return m;
+                    }
+                    i++;
+                }
+                else
+                {
+                    if (table[i] > -1)
+                    {
+                        m = m + i - table[i];
+                        i = table[i];
+                    }
+                    else
+                    {
+                        m++;
+                        i = 0;
+                    }
+                }
+            }
+
+            return -1;
+        }
+
+        #endregion
     }
 }


### PR DESCRIPTION
A hopefully not-awful fix for the issue I was running into with my `PublishSingleFile`-enabled application.
At the end of the patching process, I've added a branch that checks for when there is extra content after the PE file.
If there is, that content is rewritten after the _new_ end of the PE file, and we then check for a .NET bundle manifest. It contains offsets to all files stored after the PE file, which all must be updated - including the bundle marker stored in the `.data` freeform section.

Digging around the .NET runtime source code to find all this was quite interesting; as far as I can tell, the implementation here should work universally until the bundle format is changed again... Touch wood.

(Also, I spent too long trying to figure out the format of the bundle marker in the `.data` section to see if it could be parsed before realising that .NET itself doesn't even bother - it just searches for the magic bytes of the bundle's signature. It came together pretty quickly after that)

My reference:
https://github.com/dotnet/designs/blob/main/accepted/2020/single-file/bundler.md
https://github.com/dotnet/runtime/blob/main/src/installer/managed/Microsoft.NET.HostModel/AppHost/HostWriter.cs
https://github.com/dotnet/runtime/blob/main/src/installer/managed/Microsoft.NET.HostModel/Bundle/Manifest.cs